### PR TITLE
Move return outside loop in expoSender

### DIFF
--- a/server/services/expoSender.js
+++ b/server/services/expoSender.js
@@ -29,7 +29,7 @@ module.exports = () => ({
       } catch (error) {
         console.error(error);
       }
-      return tickets;
     }
+    return tickets;
   },
 });


### PR DESCRIPTION
I moved return of the function outside the loop, because its make imossible to iterate through chunks array. The return aborted function after loop first iterration. 